### PR TITLE
support current automake

### DIFF
--- a/Recipe
+++ b/Recipe
@@ -181,6 +181,9 @@ version.o: FORCE
 # touch whenever any source file is updated.
 !cflags am version $(VER) -DINCLUDE_EMPTY_H `if test -z "$(VER)" && (cd $(srcdir)/..; md5sum -c manifest >/dev/null 2>&1); then cat $(srcdir)/../version.def; else echo "$(VER)"; fi`
 !begin am
+AUTOMAKE_OPTIONS = subdir-objects
+!end
+!begin am
 BUILT_SOURCES = empty.h
 empty.h: $(allsources)
 	echo '/* Empty file touched by automake makefile to force rebuild of version.o */' >$@


### PR DESCRIPTION
The current automake spews warnings and fails if Makefile.am has subdirectories in it, unless the `subdir-options` option to automake is specified.  So we specify it.  The option appears to have no effect on older versions of automake.
